### PR TITLE
Feature - SWP-1743 - Fix adding card to customer via sources method

### DIFF
--- a/src/Providers/Stripe/Customer/Service.php
+++ b/src/Providers/Stripe/Customer/Service.php
@@ -97,9 +97,9 @@ class Service implements CustomerServiceInterface
             case StripeToken::TOKEN:
             default:
                 /** @var StripeCustomer $stripeCustomer */
-                $stripeCustomer = StripeCustomer::retrieve($customerUid);
+                $customerSources = StripeCustomer::allSources($customerUid);
 
-                $response = $stripeCustomer->sources->create([
+                $response = $customerSources->create([
                     'source' => $cardUid,
                 ]);
 


### PR DESCRIPTION
Currently this package allows two ways to link a card to an existing customer - through PaymentMethods or Sources. 

When trying to use Sources to create testing cards for seeding I found multiple payment cards cannot be created due to an issue in this package. 

The issue is these lines:
```$stripeCustomer = StripeCustomer::retrieve($customerUid); ```
```$response = $stripeCustomer->sources->create([```
Even when the customer has a default payment source $stripeCustomer->sources is a null collection.

Changing this to: 
```$customerSources = StripeCustomer::allSources($customerUid);```
``` $response = $customerSources->create([```
Allows additional sources to be linked to a customer as the sources have been fetched properly.

This change has fixed the breaking test on my local and allowed payment seeding to work. 